### PR TITLE
feat(quiz): Implement Recap Screen for Quiz Mode

### DIFF
--- a/app/src/main/java/com/stephenwanjala/multiply/game/feat_quizmode/QuestionsScreen.kt
+++ b/app/src/main/java/com/stephenwanjala/multiply/game/feat_quizmode/QuestionsScreen.kt
@@ -76,6 +76,10 @@ import com.stephenwanjala.multiply.game.components.neumorphicShadow
 fun QuestionsScreen(viewModel: QuestionsViewModel, onClosePressed: () -> Unit) {
     val state = viewModel.state.collectAsStateWithLifecycle().value
 
+    if (state.showRecap) {
+        RecapScreen(results = state.results, onClosePressed = onClosePressed)
+        return
+    }
     Surface(color = MaterialTheme.colorScheme.background) {
         Scaffold(
             topBar = {
@@ -424,34 +428,28 @@ fun QuestionBottomBar(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun RecapScreen(viewModel: QuestionsViewModel) {
-    Surface(
-        color = MaterialTheme.colorScheme.background,
-        modifier = Modifier
-            .fillMaxSize()
-            .glowingOrbs()
-    ) {
-        Scaffold(topBar = {
-            TopAppBar(title = { Text(text = "Recap ") }, actions = {
-                IconButton(onClick = { /*TODO*/ }) {
-                    Icon(imageVector = Icons.Default.Close, contentDescription = "Close")
-                }
-            })
-        }) { paddingValues ->
-            LazyColumn(
-                contentPadding = paddingValues
-            ) {
-//                itemsIndexed(gameResults) { index, result ->
-//                    QuestionRecapItem(questionNumber = index + 1, result = result)
-//                    Spacer(modifier = Modifier.height(8.dp))
-//                }
+fun RecapScreen(results: List<GameResult>, onClosePressed: () -> Unit) {
+    Surface(color = MaterialTheme.colorScheme.background) {
+        Scaffold(
+            topBar = {
+                TopAppBar(title = { Text("Quiz Recap", fontWeight = FontWeight.Bold) }, actions = {
+                    Button(onClick = onClosePressed) {
+                        Text("Home")
+                    }
+                })
             }
-
+        ) { padding ->
+            LazyColumn(modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()) {
+                itemsIndexed(results) { index, result ->
+                    QuestionRecapItem(questionNumber = index + 1, result = result)
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+            }
         }
     }
-
 }
-
 
 @Composable
 fun AnswerRow(answer: Int, isUserAnswer: Boolean, isCorrect: Boolean) {

--- a/app/src/main/java/com/stephenwanjala/multiply/game/feat_quizmode/QuestionsViewModel.kt
+++ b/app/src/main/java/com/stephenwanjala/multiply/game/feat_quizmode/QuestionsViewModel.kt
@@ -98,12 +98,10 @@ class QuestionsViewModel @Inject constructor(
                     isCorrect = state.value.selectedAnswers[index] == question.answer
                 )
             }
-            _state.update { it.copy(results = results) }
-            // Handle navigation to results screen
+            _state.update { it.copy(results = results, showRecap = true) }
         }
     }
 }
-
 
 data class QuestionsState(
     val currentQuestion: MathQuestion? = null,
@@ -113,10 +111,11 @@ data class QuestionsState(
     val nextButtonEnabled: Boolean = false,
     val showPreviousButton: Boolean = false,
     val showDoneButton: Boolean = false,
-    val currentQuestionIndex:Int =0,
+    val currentQuestionIndex: Int = 0,
     val selectedAnswers: Map<Int, Int> = emptyMap(),
-    val selectedAnswer: Int? = null
-    )
+    val selectedAnswer: Int? = null,
+    val showRecap: Boolean = false
+)
 
 data class GameResult(
     val question: String,


### PR DESCRIPTION
This commit introduces the Recap Screen, which displays a summary of the user's performance after completing a quiz.

- **`QuestionsViewModel.kt`**:
    - Modified `submitAnswers` to update `showRecap` to `true` in `_state` when answers are submitted.
    - Added `showRecap` (Boolean) to `QuestionsState` to control the visibility of the recap screen.
- **`QuestionsScreen.kt`**:
    - Conditionally displays `RecapScreen` when `state.showRecap` is true.
    - `RecapScreen` composable:
        - Takes `results: List<GameResult>` and `onClosePressed: () -> Unit` as parameters.
        - Displays a `Scaffold` with a `TopAppBar` titled "Quiz Recap" and a "Home" button to navigate away. - Uses a `LazyColumn` to display a list of `QuestionRecapItem` for each result.